### PR TITLE
Add color property to the TCS34725 class (closes #8).

### DIFF
--- a/adafruit_tcs34725.py
+++ b/adafruit_tcs34725.py
@@ -250,7 +250,7 @@ class TCS34725:
         Blue = 255 (0x0000ff), SlateGray = 7372944 (0x708090)
         """
         r, g, b = self.color_rgb_bytes
-        return (r << 16) + (g << 8) + b
+        return (r << 16) | (g << 8) | b
 
 
     @property

--- a/adafruit_tcs34725.py
+++ b/adafruit_tcs34725.py
@@ -242,6 +242,16 @@ class TCS34725:
         blue  = int(pow((int((b/clear) * 256) / 255), 2.5) * 255)
         return (red, green, blue)
 
+    @property
+    def color(self):
+        """Read the RGB color detected by the sensor. Returns an int with 8 bits per channel.
+
+        Examples: Red = 16711680 (0xff0000), Green = 65280 (0x00ff00),
+        Blue = 255 (0x0000ff), SlateGray = 7372944 (0x708090)
+        """
+        r, g, b = self.color_rgb_bytes
+        return (r << 16) + (g << 8) + b
+
 
     @property
     def temperature(self):


### PR DESCRIPTION
I built the module and docs locally using the instructions in the README, as well as running pylint (10.00/10). I then tested my changes with an [Adafruit Feather M0 Express](https://www.adafruit.com/product/3403) and the [Adafruit TCS34725 sensor board](https://www.adafruit.com/product/1334) using a [modified copy of the example tcs34725_simpletest.py](https://gist.github.com/process1183/39c2d4a551ac8ccfa03ed33fc3172f2b). Sample output from this script:

    Detected color: #19190C
    sensor.color = 1644812 #19190C
    Temperature: 4508.97K Lux: 721.692
    
    Detected color: #440705
    sensor.color = 4458245 #440705
    Temperature: 2961.51K Lux: 1572.29
    
    Detected color: #101010
    sensor.color = 1052688 #101010
    Temperature: 8890.37K Lux: 267.161