### PR TITLE
change color property to use scaled color_raw values

### DIFF
--- a/adafruit_tcs34725.py
+++ b/adafruit_tcs34725.py
@@ -140,7 +140,7 @@ class TCS34725:
         Examples: Red = 16711680 (0xff0000), Green = 65280 (0x00ff00),
         Blue = 255 (0x0000ff), SlateGray = 7372944 (0x708090)
         """
-        r, g, b, c = self.color_raw
+        r, g, b, _c = self.color_raw
         scaled_r = r * 255 // 1024
         scaled_g = g * 255 // 1024
         scaled_b = b * 255 // 1024

--- a/adafruit_tcs34725.py
+++ b/adafruit_tcs34725.py
@@ -140,8 +140,11 @@ class TCS34725:
         Examples: Red = 16711680 (0xff0000), Green = 65280 (0x00ff00),
         Blue = 255 (0x0000ff), SlateGray = 7372944 (0x708090)
         """
-        r, g, b = self.color_rgb_bytes
-        return (r << 16) | (g << 8) | b
+        r, g, b, c = self.color_raw
+        scaled_r = r * 255 // 1024
+        scaled_g = g * 255 // 1024
+        scaled_b = b * 255 // 1024
+        return (scaled_r << 16) | (scaled_g << 8) | scaled_b
 
     @property
     def active(self):


### PR DESCRIPTION
Solves #18 

Tested with: https://www.adafruit.com/product/1356

If I understand the docs in `color_raw` correctly the values should range from (0-65535). At first I tried scaling down from there to 0-255 for this but I was only getting VERY low colors or black.

I set up script to print the `color_raw` values and `1024` was the maximum value I observed for any color or clear channel. Most easily achieved by putting white paper in front of the sensor very close. 

After adjusting the scaling to use the `1024` maximum I am seeing a good range of colors when various objects are placed in front of the sensor. 

In comparison with `color_rgb_bytes` the colors this version returns tend to be similar but a bit brighter. 

