### PR TITLE
Update to the test file of the TCS34725 color sensor 

### DIFF
--- a/adafruit_tcs34725.py
+++ b/adafruit_tcs34725.py
@@ -141,8 +141,7 @@ class TCS34725:
 
         """Each color value is normalized to clear, to obtain int values between 0 and 255.
         A gamma correction of 2.5 is applied to each value as well, first dividing by 255,
-        since gamma is applied to values between 0 and 1
-        """
+        since gamma is applied to values between 0 and 1 """
         red = int(pow((int((r / clear) * 256) / 255), 2.5) * 255)
         green = int(pow((int((g / clear) * 256) / 255), 2.5) * 255)
         blue = int(pow((int((b / clear) * 256) / 255), 2.5) * 255)

--- a/adafruit_tcs34725.py
+++ b/adafruit_tcs34725.py
@@ -139,9 +139,9 @@ class TCS34725:
         if clear == 0:
             return (0, 0, 0)
 
-        """Each color value is normalized to clear, to obtain int values between 0 and 255.
-        A gamma correction of 2.5 is applied to each value as well, first dividing by 255,
-        since gamma is applied to values between 0 and 1 """
+        # Each color value is normalized to clear, to obtain int values between 0 and 255.
+        # A gamma correction of 2.5 is applied to each value as well, first dividing by 255,
+        # since gamma is applied to values between 0 and 1
         red = int(pow((int((r / clear) * 256) / 255), 2.5) * 255)
         green = int(pow((int((g / clear) * 256) / 255), 2.5) * 255)
         blue = int(pow((int((b / clear) * 256) / 255), 2.5) * 255)

--- a/adafruit_tcs34725.py
+++ b/adafruit_tcs34725.py
@@ -134,12 +134,19 @@ class TCS34725:
         red, green, blue component values as bytes (0-255).
         """
         r, g, b, clear = self.color_raw
+
         # Avoid divide by zero errors ... if clear = 0 return black
         if clear == 0:
             return (0, 0, 0)
+
+        """Each color value is normalized to clear, to obtain int values between 0 and 255.
+        A gamma correction of 2.5 is applied to each value as well, first dividing by 255,
+        since gamma is applied to values between 0 and 1
+        """
         red = int(pow((int((r / clear) * 256) / 255), 2.5) * 255)
         green = int(pow((int((g / clear) * 256) / 255), 2.5) * 255)
         blue = int(pow((int((b / clear) * 256) / 255), 2.5) * 255)
+
         # Handle possible 8-bit overflow
         if red > 255:
             red = 255

--- a/examples/tcs34725_simpletest.py
+++ b/examples/tcs34725_simpletest.py
@@ -12,11 +12,24 @@ import adafruit_tcs34725
 i2c = board.I2C()  # uses board.SCL and board.SDA
 sensor = adafruit_tcs34725.TCS34725(i2c)
 
+# Change sensor integration time to values between 2.4 and 614.4 milliseconds
+# sensor.integration_time = 150
+
+# Change sensor gain to 1, 4, 16, or 60
+# sensor.gain = 4
+
 # Main loop reading color and printing it every second.
 while True:
+    # Raw data from the sensor in a 4-tuple of red, green, blue, clear light component values
+    # print(sensor.color_raw)
+
+    color = sensor.color
+    color_rgb = sensor.color_rgb_bytes
+    print("RGB color as 8 bits per channel int: #{0:02X} or as 3-tuple: {1}".format(color, color_rgb))
+
     # Read the color temperature and lux of the sensor too.
     temp = sensor.color_temperature
     lux = sensor.lux
-    print("Temperature: {0}K Lux: {1}".format(temp, lux))
+    print("Temperature: {0}K Lux: {1}\n".format(temp, lux))
     # Delay for a second and repeat.
     time.sleep(1.0)

--- a/examples/tcs34725_simpletest.py
+++ b/examples/tcs34725_simpletest.py
@@ -25,7 +25,11 @@ while True:
 
     color = sensor.color
     color_rgb = sensor.color_rgb_bytes
-    print("RGB color as 8 bits per channel int: #{0:02X} or as 3-tuple: {1}".format(color, color_rgb))
+    print(
+        "RGB color as 8 bits per channel int: #{0:02X} or as 3-tuple: {1}".format(
+            color, color_rgb
+        )
+    )
 
     # Read the color temperature and lux of the sensor too.
     temp = sensor.color_temperature


### PR DESCRIPTION
Added more examples of how to read the data form the color sensor in `tcs34725_simpletest.py.`  

Also added a comment explaining the gamma correction calculations that are done on the raw values from the sensor in `color_rgb_bytes` from `adafruit_tcs34725.py`.