### PR TITLE
feat: Add support for device ID 0x4D

### DIFF
--- a/adafruit_tcs34725.py
+++ b/adafruit_tcs34725.py
@@ -121,7 +121,7 @@ class TCS34725:
         self.glass_attenuation = 1.0
         # Check sensor ID is expectd value.
         sensor_id = self._read_u8(_REGISTER_SENSORID)
-        if sensor_id not in (0x44, 0x10):
+        if sensor_id not in (0x44, 0x10, 0x4D):
             raise RuntimeError("Could not find sensor, check wiring!")
 
     @property


### PR DESCRIPTION
## Add support for device TCS34727

The device TCS34727 returns `0x4D` (by [PDF](https://www.alldatasheet.co.kr/datasheet-pdf/pdf_kor/894929/AMSCO/TCS34727.html) table in page 27)

Arduino code already support this ID.
* https://github.com/adafruit/Adafruit_TCS34725/blob/6dfa7123306cafea3ad9fb108f2af48a67d090d1/Adafruit_TCS34725.cpp#L144
* https://github.com/adafruit/Adafruit_TCS34725/commit/7ffe37e061d4484f8056071c03dfda708a3beabe
